### PR TITLE
Nested messages can generate duplicate code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,9 @@ task createClasspathManifest {
 dependencies {
     compile gradleApi()
 
-    provided 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
+    provided('com.google.protobuf:protobuf-gradle-plugin:0.8.5') {
+        exclude group: "com.google.guava"
+    }
     compile "org.reflections:reflections:0.9.11"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
@@ -102,6 +104,7 @@ dependencies {
     compile('com.squareup:kotlinpoet:0.7.0') {
         exclude group: "org.jetbrains.kotlin"
     }
+    compile 'com.google.guava:guava:23.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.natpryce:hamkrest:1.3.0.0'

--- a/src/main/kotlin/org/protokruft/GenerateProtobufDsl.kt
+++ b/src/main/kotlin/org/protokruft/GenerateProtobufDsl.kt
@@ -18,6 +18,7 @@ typealias TargetMessageClasses = () -> Iterable<ClassName>
 fun ScanClasspath(pkg: String) = {
     Reflections(pkg).getSubTypesOf(GeneratedMessageV3::class.java)
             .map { it.kotlin }
+            .filter { it.java.declaringClass?.declaringClass == null }
             .sortedBy { it.qualifiedName }
             .map { it.asClassName() }
 }

--- a/src/main/kotlin/org/protokruft/GenerateProtobufDslTask.kt
+++ b/src/main/kotlin/org/protokruft/GenerateProtobufDslTask.kt
@@ -39,11 +39,17 @@ fun GeneratedProtos(project: Project, packageNames: Set<String>?): TargetMessage
                         project.logger.debug("Protokruft: found files: " + it.toString())
                     }
 
+    fun isTopLevelClass(className: String): Boolean = className.count { it == '.' } == 1
+
     fun findAllClassesIn(input: String, pkg: String) = Regex("public static (.*) parseFrom")
             .findAll(input).map { it.groupValues[1] }
             .distinct()
             .toList()
             .map { it.removePrefix("$pkg.") }
+            .filter(::isTopLevelClass)
+            .also {
+                project.logger.debug("Protokruft: found classes: ${it.joinToString(", ")}")
+            }
 
     project.logger.debug("Protokruft: filtering classes to packages: " + (packageNames?.toString() ?: "*"))
 

--- a/src/main/proto/example3.proto
+++ b/src/main/proto/example3.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "org.protokruft.example3";
+package AnExample3;
+
+message Cat {
+    message Leg {}
+}
+
+message Leg {}

--- a/src/test/kotlin/org/protokruft/GenerateProtobufDslTest.kt
+++ b/src/test/kotlin/org/protokruft/GenerateProtobufDslTest.kt
@@ -16,8 +16,9 @@ class GenerateProtobufDslTest {
             assertThat(w.toString(), equalTo(javaClass.getResourceAsStream("/expected$i.ktt").reader().readText()))
         }
 
-        assertThat(generated.size, equalTo(2))
+        assertThat(generated.size, equalTo(3))
         check(1)
         check(2)
+        check(3)
     }
 }

--- a/src/test/kotlin/org/protokruft/ProtokruftPluginRealBuildTest.kt
+++ b/src/test/kotlin/org/protokruft/ProtokruftPluginRealBuildTest.kt
@@ -24,21 +24,24 @@ class ProtokruftPluginRealBuildTest {
         resourceTo("/build.gradle", testProjectDir.root)
         resourceTo("/example1.proto", File(testProjectDir.root, "src/main/proto"))
         resourceTo("/example2.proto", File(testProjectDir.root, "src/main/proto"))
+        resourceTo("/example3.proto", File(testProjectDir.root, "src/main/proto"))
         val pluginClasspathResource = File(javaClass.classLoader.getResource("plugin-classpath.txt").file)
         pluginClasspath = pluginClasspathResource.reader().readLines().map { File(it) }
     }
 
     @Test
     fun generatesOutputForProtobufFiles() {
-        GradleRunner.create()
+        val result = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withPluginClasspath(pluginClasspath)
                 .withArguments("clean", "generateProto", NAME, "--debug")
                 .build()
 
-        val expected = File(testProjectDir.root, "build/generated/source/proto/main/java/org/protokruft/example1/custom.kt").readText()
+        println(result.output)
+
+        val expected = File(testProjectDir.root, "build/generated/source/proto/main/java/org/protokruft/example3/custom.kt").readText()
         val excluded = File(testProjectDir.root, "build/generated/source/proto/main/java/org/protokruft/example2/custom.kt")
-        assertThat(expected, equalTo(javaClass.getResourceAsStream("/expected1.ktt").reader().readText()))
+        assertThat(expected, equalTo(javaClass.getResourceAsStream("/expected3.ktt").reader().readText()))
         assertThat("excluded package was generated " + excluded.absolutePath, excluded.exists(), equalTo(false))
     }
 

--- a/src/test/resources/build.gradle
+++ b/src/test/resources/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 protokruft {
     outputClassFile = "custom"
-    packageNames = [ "org.protokruft.example1" ]
+    packageNames = [ "org.protokruft.example3" ]
 }
 
 protobuf {

--- a/src/test/resources/example3.proto
+++ b/src/test/resources/example3.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "org.protokruft.example3";
+package AnExample3;
+
+message Cat {
+    message Leg {}
+}
+
+message Leg {}

--- a/src/test/resources/expected3.ktt
+++ b/src/test/resources/expected3.ktt
@@ -1,0 +1,23 @@
+package org.protokruft.example3
+
+import kotlin.Unit
+
+object newCat {
+    private fun new(): Example3.Cat.Builder = org.protokruft.example3.Example3.Cat.newBuilder()
+
+    operator fun invoke(fn: Example3.Cat.Builder.() -> Unit): Example3.Cat = new().apply(fn).build()
+
+    fun apply(fn: Example3.Cat.Builder.() -> Unit): Example3.Cat = invoke(fn)
+
+    fun also(fn: (Example3.Cat.Builder) -> Unit): Example3.Cat = new().apply(fn).build()
+}
+
+object newLeg {
+    private fun new(): Example3.Leg.Builder = org.protokruft.example3.Example3.Leg.newBuilder()
+
+    operator fun invoke(fn: Example3.Leg.Builder.() -> Unit): Example3.Leg = new().apply(fn).build()
+
+    fun apply(fn: Example3.Leg.Builder.() -> Unit): Example3.Leg = invoke(fn)
+
+    fun also(fn: (Example3.Leg.Builder) -> Unit): Example3.Leg = new().apply(fn).build()
+}


### PR DESCRIPTION
If there's a nested message with the same name as an existing message in the enclosing package, Protokruft will generate duplicate code.